### PR TITLE
Grey out Windows and MacOS columns

### DIFF
--- a/css/beginners.css
+++ b/css/beginners.css
@@ -124,6 +124,10 @@ th {
   padding: 18px 20px;
 }
 
+/* Greying out Windows and MacOS columns for absent recommendation to start */
+td:nth-child(4) { background-color: var(--alt-white); }
+td:nth-child(5) { background-color: var(--alt-white); }
+
 .table-header-cell-main {
   width: 200px;
 }
@@ -141,7 +145,7 @@ th {
   color: #AFB5BF;
 }
 
-.table-version-cell{
+.table-version-cell {
   width: 200px;
 }
 


### PR DESCRIPTION
Maybe grey out the columns to nudge towards Ubuntu?

We'll probably be better off changing the icons too.

![image](https://github.com/user-attachments/assets/cccc3ad0-1336-494f-911c-7c55c2f42eae)
