### PR TITLE
Add Ubuntu Focal to the table of supported versions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,6 +262,7 @@
                 <th class="table-header-cell-main">Version</th>
                 <th class="table-header-cell">Ubuntu Noble</th>
                 <th class="table-header-cell">Ubuntu Jammy</th>
+                <th class="table-header-cell">Ubuntu Focal</th>
                 <th class="table-header-cell">Windows 10</th>
                 <th class="table-header-cell">MacOS</th>
               </tr>
@@ -271,6 +272,9 @@
                 <td class="table-version-cell">Jazzy Jalisco</td>
                 <td class="table-data-cell">
                   <img src="/images/recommended-to-start.png" alt="Recommended support icon" class="table-icon" width="28" height="28">
+                </td>
+                <td class="table-data-cell">
+                  <img src="/svgs/community-support.svg" alt="Community support icon" class="table-icon" width="28" height="28">
                 </td>
                 <td class="table-data-cell">
                   <img src="/svgs/not-support.svg" alt="Not support icon" class="table-icon" width="28" height="28">
@@ -291,6 +295,9 @@
                   <img src="/images/recommended-to-start.png" alt="Recommended support icon" class="table-icon" width="28" height="28">
                 </td>
                 <td class="table-data-cell">
+                  <img src="/svgs/community-support.svg" alt="Community support icon" class="table-icon" width="28" height="28">
+                </td>
+                <td class="table-data-cell">
                   <img src="/svgs/recommended-to-use.svg" alt="Recommended to use icon" class="table-icon" width="28" height="28">
                 </td>
                 <td class="table-data-cell">
@@ -301,6 +308,9 @@
                 <td class="table-version-cell">Rolling Ridley</td>
                 <td class="table-data-cell">
                   <img src="/svgs/recommended-to-use.svg" alt="Recommended to use icon" class="table-icon" width="28" height="28">
+                </td>
+                <td class="table-data-cell">
+                  <img src="/svgs/not-support.svg" alt="Not support icon" class="table-icon" width="28" height="28">
                 </td>
                 <td class="table-data-cell">
                   <img src="/svgs/not-support.svg" alt="Not support icon" class="table-icon" width="28" height="28">


### PR DESCRIPTION
This is important mostly because of NVIDIA users, who are often stuck on ancient versions of software.

Note that I also added Ubuntu Jammy as a "Community support" to Jazzy, which is indicated on
https://docs.ros.org/en/jazzy/Installation/Alternatives/Ubuntu-Development-Setup.html .

Note that there is an open PR to fix this latter point in REP-2000 as well: https://github.com/ros-infrastructure/rep/pull/413