### PR TITLE
Remove Discord link and add Zulip link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,7 +383,6 @@
           <div id="helpful-resources-link-list-column-1" class="helpful-resources-link-list">
             <a href="https://discourse.ros.org/" class="helpful-resources-link">ROS Discourse Forum</a>
 	    <a href="https://openrobotics.zulipchat.com/" class="helpful-resources-link">Official Zulip Server</a>
-            <a href="https://discord.com/servers/open-robotics-1077825543698927656" class="helpful-resources-link">ROS Discord Server</a>
             <a href="https://robotics.stackexchange.com/" class="helpful-resources-link">Ask a ROS Question</a>
             <a href="https://discourse.ros.org/tag/weekly-update" class="helpful-resources-link"> Latest ROS News </a>
             <a href="https://vimeo.com/osrfoundation" class="helpful-resources-link">Official ROS Videos</a>
@@ -650,7 +649,7 @@
           <a href="https://discourse.ros.org/" class="footer-menu-link">FORUM</a>
         </div>
         <div class="footer-menu-tight">
-          <a href="https://discord.com/servers/open-robotics-1077825543698927656" class="footer-menu-link">DISCORD</a>
+          <a href="https://openrobotics.zulipchat.com/" class="footer-menu-link">ZULIP</a>
         </div>
         <div class="footer-menu-wide">
           <a href="https://index.ros.org/" class="footer-menu-link">PACKAGES</a>


### PR DESCRIPTION
Remove notion of discord and changed the footer discord link to Zulip