### PR TITLE
Maybe ~/.ssh doesn't exist at deploy action?

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,9 +17,9 @@ jobs:
           SSH_HOST_PUB_KEY: ${{ secrets.SSH_HOST_PUB_KEY }}
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         run: |
-          echo $SSH_HOST_PUB_KEY >> ~/.ssh/known_hosts
-          install -m 0600 -D /dev/null ~/.ssh/deploy_key
-          echo $SSH_DEPLOY_KEY > ~/.ssh/deploy_key
+          echo $SSH_HOST_PUB_KEY >> "$HOME/.ssh/known_hosts"
+          install -m 0600 -D /dev/null "$HOME/.ssh/deploy_key"
+          echo $SSH_DEPLOY_KEY > "$HOME/.ssh/deploy_key"
       - name: deploy
         env:
           SSH_ARGS: "-i $HOME/.ssh/deploy_key"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,9 +17,10 @@ jobs:
           SSH_HOST_PUB_KEY: ${{ secrets.SSH_HOST_PUB_KEY }}
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         run: |
-          echo $SSH_HOST_PUB_KEY >> "$HOME/.ssh/known_hosts"
-          install -m 0600 -D /dev/null "$HOME/.ssh/deploy_key"
-          echo $SSH_DEPLOY_KEY > "$HOME/.ssh/deploy_key"
+          mkdir -p ~/.ssh
+          echo $SSH_HOST_PUB_KEY >> ~/.ssh/known_hosts
+          install -m 0600 -D /dev/null ~/.ssh/deploy_key
+          echo $SSH_DEPLOY_KEY > ~/.ssh/deploy_key
       - name: deploy
         env:
           SSH_ARGS: "-i $HOME/.ssh/deploy_key"


### PR DESCRIPTION
I'm not sure why the deploy action is failing. Maybe `~/.ssh` doesn't exist?

https://github.com/ros-infrastructure/docs-landing-page/actions/runs/26279116681/job/77350624286

```
  echo $SSH_HOST_PUB_KEY >> ~/.ssh/known_hosts
  install -m 0600 -D /dev/null ~/.ssh/deploy_key
  echo $SSH_DEPLOY_KEY > ~/.ssh/deploy_key
  shell: /usr/bin/bash -e {0}
  env:
    SSH_HOST_PUB_KEY: ***
    SSH_DEPLOY_KEY: ***
/home/runner/work/_temp/5b75ce03-ba1e-40ed-ad2f-9ab383f45689.sh: line 1: /home/runner/.ssh/known_hosts: No such file or directory
```